### PR TITLE
Add severity-dynamic test playbook

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,7 @@ Utility playbooks for testing Satori functionality.
 | Playbook | Tool | Description |
 |----------|------|-------------|
 | [severity.yml](severity.yml) | Severity Test | Validates severity level assertions from Blocker (0) to Informational (5) |
+| [severity-dynamic.yml](severity-dynamic.yml) | Dynamic Severity | Validates that `setSeverity: <path>.stdout` is resolved at report time from the referenced command's stdout |
 
 ## Usage
 

--- a/test/severity-dynamic.yml
+++ b/test/severity-dynamic.yml
@@ -1,0 +1,28 @@
+settings:
+  name: "Test: Dynamic Severity"
+  description: "Validates that setSeverity accepts a path.stdout reference and the analyzer resolves it at report time."
+  image: satori
+  author:
+    - https://github.com/satorici
+  example: satori local satori://test/severity-dynamic.yml --report
+
+# Deterministic case: severity is derived from a fixed echo.
+severity:
+  - echo 3
+
+deterministic:
+  setSeverity: severity.stdout
+  cmd:
+    - echo Output
+  assertReturnCode: 0
+
+# Random case (Fernando's original example): exercises the dynamic path
+# without coupling the test to a specific severity value.
+randomSeverity:
+  - bash -c "echo $((RANDOM % 6))"
+
+random:
+  setSeverity: randomSeverity.stdout
+  cmd:
+    - echo Output
+  assertReturnCode: 0


### PR DESCRIPTION
## Summary
- Add `test/severity-dynamic.yml` exercising the new `setSeverity: <path>.stdout` form: a deterministic `echo 3`-based case and the original random-severity example.
- Update `test/README.md` to list the new fixture.

Depends on companion PRs in `satorici/playbook-validator` (schema) and `satorici/analyze` (resolver) — the playbook is invalid against the current published schema until those land.

## Test plan
- [x] Schema-validated against the `dynamic-severity` branch of `playbook-validator`
- [ ] `satori local satori://test/severity-dynamic.yml --report` after the analyze + validator PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)