### PR TITLE
osint: fix domain-to-github (hyphenated domains) + add github-emails harvester

### DIFF
--- a/osint/domain-to-github.yml
+++ b/osint/domain-to-github.yml
@@ -14,7 +14,7 @@ find_account:
     - |
       DOMAIN="${{DOMAIN}}"
       CORE="${DOMAIN%%.*}"
-      FLAT="$(echo "$DOMAIN" | tr -d '.')"
+      FLAT="$(echo "$CORE" | tr -cd 'a-zA-Z0-9')"
       if [ -n "$GITHUB_TOKEN" ]; then
         gh(){ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$@"; }
       else
@@ -23,7 +23,7 @@ find_account:
       norm(){ echo "$1" | sed -E 's#https?://##; s#^www\.##; s#/.*$##' | tr 'A-Z' 'a-z'; }
 
       echo "### Resolving '$DOMAIN' (core='$CORE')"
-      CANDS="$( { gh "https://api.github.com/search/users?q=${CORE}&per_page=20" | jq -r '.items[]?.login' 2>/dev/null; echo "$CORE"; echo "$FLAT"; } | sort -u )"
+      CANDS="$( { gh "https://api.github.com/search/users?q=${CORE}&per_page=20" | jq -r '.items[]?.login' 2>/dev/null; gh "https://api.github.com/search/users?q=${FLAT}&per_page=20" | jq -r '.items[]?.login' 2>/dev/null; echo "$CORE"; echo "$FLAT"; } | sort -u )"
       BEST=""; BEST_SCORE=-1
 
       printf "%-22s %-14s %-7s %s\n" "LOGIN" "TYPE" "SCORE" "WEBSITE"
@@ -52,6 +52,8 @@ find_account:
       sort -t"$(printf '\t')" -k1,1 -k2,2 "$ROWS" | cut -f3-
       rm -f "$ROWS"
       echo "BEST_MATCH=${BEST} (score=${BEST_SCORE}) https://github.com/${BEST}"
+      # Producer artifact: clean, machine-readable result for downstream/imported playbooks
+      mkdir -p /tmp/satori/out && printf '%s\n' "$BEST" > /tmp/satori/out/github-org
 
   resolved:
     setOutput: find_account.run

--- a/osint/github-emails.yml
+++ b/osint/github-emails.yml
@@ -1,0 +1,47 @@
+settings:
+  name: "Domain to GitHub emails"
+  description: "Given only a DOMAIN, resolves its most likely GitHub org (via domain-to-github) and harvests committer/author emails from that org public repositories. Highlights on-target emails matching the domain. No API key required; runs unauthenticated using the Satori container IP."
+  image: debian:stable-slim
+  author:
+    - https://github.com/satorici
+  gallery:
+    - https://files.catbox.moe/poush8.png
+  example: satori run satori://osint/github-emails.yml -d DOMAIN=satori-ci.com --report --output
+
+import:
+  - satori://osint/domain-to-github.yml
+
+harvest_emails:
+  install:
+    - export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -qy --no-install-recommends curl jq ca-certificates >/dev/null 2>&1
+
+  run:
+    - |
+      DOMAIN="${{DOMAIN}}"
+      ORG="$(cat /tmp/satori/out/github-org 2>/dev/null)"
+      echo "### Resolved org from domain-to-github: '$ORG'  (domain: $DOMAIN)"
+      if [ -z "$ORG" ]; then echo "No org resolved, nothing to harvest"; exit 1; fi
+      API="https://api.github.com"
+      : > /tmp/all_emails.txt
+      REPOS="$(curl -s "$API/orgs/$ORG/repos?per_page=30&sort=pushed&type=public" | jq -r '.[]?.name' 2>/dev/null)"
+      echo "Public repos scanned (top 30 by push):"
+      echo "$REPOS" | tr '\n' ' '; echo
+      for R in $REPOS; do
+        curl -s "$API/repos/$ORG/$R/commits?per_page=100" \
+          | jq -r '.[]?.commit | (.author.email, .committer.email)' 2>/dev/null
+      done \
+        | grep -aiE '^[^@[:space:]]+@[^@[:space:]]+\.[a-z]{2,}$' \
+        | grep -aviE 'noreply|\.internal|\.local$|\.lan$|localhost|\.localdomain|\.ec2\.|example\.(com|org)' \
+        | tr 'A-Z' 'a-z' | sort -u > /tmp/all_emails.txt
+      echo ""
+      ESC="$(printf '%s' "$DOMAIN" | sed 's/[.]/\\./g')"
+      grep -iE "@$ESC$" /tmp/all_emails.txt > /tmp/target_emails.txt || true
+      echo "=== Emails matching @$DOMAIN ==="
+      cat /tmp/target_emails.txt
+      echo ""
+      echo "TOTAL @$DOMAIN: $(wc -l < /tmp/target_emails.txt | tr -d ' ')   (out of $(wc -l < /tmp/all_emails.txt | tr -d ' ') distinct commit emails scanned)"
+
+  resolved:
+    setOutput: harvest_emails.run
+    assertStdoutContains: "Emails matching @"
+    assertStdoutNotContains: "API rate limit exceeded"


### PR DESCRIPTION
## Summary
Composable, domain-only GitHub email discovery — proven end to end.

### `osint/domain-to-github.yml` (fix)
- **Bug:** `FLAT` was derived as `tr -d '.'` over the whole domain → `satori-ci.com` became `satori-cicom`, so hyphenated/multi-label domains resolved to an **empty `BEST_MATCH`**. Now `FLAT` is derived from `CORE` stripping non-alphanumerics → `satorici`.
- Also searches GitHub users by `FLAT` to improve recall.
- Emits a clean **producer artifact** `/tmp/satori/out/github-org` for downstream/imported playbooks.

### `osint/github-emails.yml` (new)
- Imports `domain-to-github`, resolves the org from **DOMAIN alone**, then harvests committer/author emails from the org public repos and highlights on-target **`@DOMAIN`** matches.
- Filters CI/`noreply`/`*.internal`/`localhost` noise. Unauthenticated (uses the Satori container IP), no API key.

## Validation
- `domain-to-github -d DOMAIN=satori-ci.com` → `BEST_MATCH=satorici` (was empty before the fix).
- `github-emails -d DOMAIN=quorumcyber.com` → resolves org `quorumcyber`, returns real on-target emails (`andrius.korsakas@`, `jacob.connell@`) and reveals the `{first}.{last}@` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)